### PR TITLE
Current transaction records

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -173,7 +173,12 @@ module ActiveRecord
         if options.has_key?(:remember_record_state)
           remember_record_state = options[:remember_record_state]
         else
-          remember_record_state = true
+          # Child transactions where parents have run with
+          # +remember_record_state+ of false will end up with
+          # @_current_transaction_records.blank == [nil, nil]. In that case
+          # this condition will set the child's +remember_record_state+
+          # also to false
+          remember_record_state = (@_current_transaction_records.blank? || !@_current_transaction_records.last.nil?)
         end
         requires_new = options[:requires_new] || !last_transaction_joinable
 


### PR DESCRIPTION
Will
Thanks for the changes you have put in to expose remember_record_state

The change I am making allows the property +remember_record_state+ to be inherited by child transactions when the base transaction at level 0 has specified it to be false. 

This turned out to be invaluable for us because we have a use case of nested transactions where much of the heavy lifting was being done in the inner transactions.

Let me know if you have any questions. 

Regards
